### PR TITLE
Bump default devspace version to 0.5.1

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,7 +10,7 @@ snoopy_dir_path: ""
 # devspace source
 devspace_git_repo: "https://github.com/openmicroscopy/devspace.git"
 # devspace branch
-devspace_git_repo_version: "0.4.1"
+devspace_git_repo_version: "0.5.0"
 # Options
 devspace_git_update: no
 devspace_git_force: no

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,7 +10,7 @@ snoopy_dir_path: ""
 # devspace source
 devspace_git_repo: "https://github.com/openmicroscopy/devspace.git"
 # devspace branch
-devspace_git_repo_version: "0.5.0"
+devspace_git_repo_version: "0.5.1"
 # Options
 devspace_git_update: no
 devspace_git_force: no


### PR DESCRIPTION
Following the release of [devspace 0.5.0](https://github.com/openmicroscopy/devspace/releases/tag/0.5.0).

As `devspace` is using `docker-compose`, I suspect Travis cannot be used for minimal testing? /cc @manics