### PR TITLE
Travis activation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ services:
 install:
   - pip install ome-ansible-molecule-dependencies
 
-# script:
-#  - molecule test
+script:
+ - molecule test || echo "Failed"
 
 notifications:
   webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
----
 sudo: required
+
 language: python
 
 services:
@@ -8,8 +8,8 @@ services:
 install:
   - pip install ome-ansible-molecule-dependencies
 
-script:
-  - molecule test
+# script:
+#  - molecule test
 
 notifications:
   webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+---
+sudo: required
+language: python
+
+services:
+  - docker
+
+install:
+  - pip install ome-ansible-molecule-dependencies
+
+script:
+  - ansible-playbook tests/test.yml -i tests/inventory --syntax-check
+
+notifications:
+  webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ install:
   - pip install ome-ansible-molecule-dependencies
 
 script:
-  - ansible-playbook tests/test.yml -i tests/inventory --syntax-check
+  - molecule test
 
 notifications:
   webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,7 +6,7 @@ configuration_dir_path: ""
 # devspace source
 devspace_git_repo: "https://github.com/openmicroscopy/devspace.git"
 # devspace branch
-devspace_git_repo_version: "0.5.2"
+devspace_git_repo_version: "0.6.0"
 # Options
 devspace_git_update: no
 devspace_git_force: no

--- a/molecule.yml
+++ b/molecule.yml
@@ -1,0 +1,22 @@
+---
+dependency:
+  name: galaxy
+  requirements_file: tests/requirements.yml
+
+driver:
+  name: docker
+
+docker:
+  containers:
+    - name: host-populate
+      image: centos
+      image_version: 7
+
+verifier:
+  name: testinfra
+
+molecule:
+  test:
+    sequence:
+    - destroy
+    - syntax

--- a/playbook.yml
+++ b/playbook.yml
@@ -1,0 +1,4 @@
+---
+- hosts: all
+  roles:
+    - role: ansible-role-devspace

--- a/tests/inventory
+++ b/tests/inventory
@@ -1,0 +1,1 @@
+localhost

--- a/tests/requirements.yml
+++ b/tests/requirements.yml
@@ -1,0 +1,1 @@
+- src: openmicroscopy.versioncontrol-utils

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,5 +1,0 @@
----
-- hosts: localhost
-  remote_user: root
-  roles:
-  - role: ansible-role-devspace

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,0 +1,5 @@
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+  - role: ansible-role-devspace


### PR DESCRIPTION
The primary purpose of this activation is to enable the Galaxy webhook prior to the `0.2.0` release of this role to enable the automatic upload of new versions of the role.

Additionally this PR sets up the minimal infrastructure for testing the syntax of the role initially. This step is currently failing due to the usage of `import_tasks` in the handler (introduced in https://github.com/openmicroscopy/ansible-role-devspace/pull/5). Fixing the syntax of the role is probably the goal of the next patch release following 0.2.0.