### PR TITLE
Cap pip

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -45,7 +45,7 @@
     #extra_args: "--upgrade"
     state: latest
   with_items:
-    - pip
+    - pip==9.0.3
     - passlib
     - pyyaml
     - docker-compose

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,3 +1,3 @@
 ---
 
-number_instance: 5
+number_instance: 2


### PR DESCRIPTION
This is necessary in order to build a devspace
The number of instance has also been reduced otherwise an error occurs while scaling selenium firefox

See https://github.com/openmicroscopy/devspace/pull/101